### PR TITLE
adds default cat gif when imags are missing

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,6 +1,6 @@
 function getInterestingFields(contentItem){
     //console.log(contentItem);
-    var mainImage = getImageFromElements(contentItem.elements)
+    var mainImage = getImage(contentItem);
     return {
         headline: contentItem.fields.headline,
         trailText: contentItem.fields.trailText,

--- a/uglyscript.js
+++ b/uglyscript.js
@@ -17,6 +17,11 @@ if (jQuery.when.all===undefined) {
     }
 }
 
+function getImage(content) {
+    if (content.elements) getImageFromElements(content.elements);
+    else return "https://media.giphy.com/media/l4KibK3JwaVo0CjDO/giphy.gif";
+}
+
 function getImageFromElements(elements) {
     var mainImageElements =  elements.filter(function(element) {
             return element.relation === "main" && element.type === "image";
@@ -30,7 +35,7 @@ function getImageFromElements(elements) {
             return mainImage.file
         }
     }
-    return null;
+    return "https://media.giphy.com/media/l4KibK3JwaVo0CjDO/giphy.gif";
 }
 
 function addApiParameters(url, key, pageSize) {

--- a/uglyscript.js
+++ b/uglyscript.js
@@ -1,5 +1,7 @@
 var articleBlockSource = $("#article-list").html();
 var articleBlockTemplate = Handlebars.compile(articleBlockSource);
+// This is, of course, a cat toboganning down the stairs
+var fallbackImage = "https://media.giphy.com/media/l4KibK3JwaVo0CjDO/giphy.gif";
 
 // Put somewhere in your scripting environment
 if (jQuery.when.all===undefined) {
@@ -19,7 +21,7 @@ if (jQuery.when.all===undefined) {
 
 function getImage(content) {
     if (content.elements) getImageFromElements(content.elements);
-    else return "https://media.giphy.com/media/l4KibK3JwaVo0CjDO/giphy.gif";
+    else return fallbackImage;
 }
 
 function getImageFromElements(elements) {
@@ -35,7 +37,7 @@ function getImageFromElements(elements) {
             return mainImage.file
         }
     }
-    return "https://media.giphy.com/media/l4KibK3JwaVo0CjDO/giphy.gif";
+    return fallbackImage;
 }
 
 function addApiParameters(url, key, pageSize) {


### PR DESCRIPTION
😺

Stops error if an article doesn't have images or an API key is used which doesn't have access to images. More cats in our journalism. 

![screen shot 2017-12-04 at 16 46 30](https://user-images.githubusercontent.com/8484757/33564678-0290c86a-d913-11e7-91e4-fd14fe952056.jpg)

