### PR TITLE
Just use thumbnail image for mainImage

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,9 +1,8 @@
 function getInterestingFields(content){
-    var mainImage = getImage(content);
     return {
         headline: content.fields.headline,
         trailText: content.fields.trailText,
-        mainImage: mainImage
+        mainImage: content.fields.thumbnail
     }
 }
 


### PR DESCRIPTION
`getImage` requires an internal content api key (to access the elements of an article), it was necessary in the past because the thumbnails were really rubbish quality but they seem ok now, so lets use them for this, which makes the project more usable outside the guardian